### PR TITLE
fix: Améliorer la visibilité du bouton d'ajout de repas dans le calendrier

### DIFF
--- a/frontend/src/features/calendar/components/MonthView.tsx
+++ b/frontend/src/features/calendar/components/MonthView.tsx
@@ -138,7 +138,7 @@ const MonthView: React.FC = () => {
                       <Button
                         size="sm"
                         variant="ghost"
-                        className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                        className="h-6 w-6 p-0 opacity-40 hover:opacity-100 transition-opacity"
                         onClick={(e) => handleAddMealClick(dateString, e)}
                       >
                         <Plus className="h-4 w-4" />

--- a/frontend/src/features/calendar/components/WeekView.tsx
+++ b/frontend/src/features/calendar/components/WeekView.tsx
@@ -109,7 +109,7 @@ const WeekView: React.FC = () => {
                       <Button
                         size="sm"
                         variant="ghost"
-                        className="absolute top-0 right-0 h-6 w-6 p-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                        className="absolute top-0 right-0 h-6 w-6 p-0 opacity-40 hover:opacity-100 transition-opacity"
                         onClick={(e) => handleAddMealClick(dateString, e)}
                       >
                         <Plus className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- Amélioration de la visibilité du bouton '+' pour ajouter des repas depuis les cases du calendrier
- Le bouton est maintenant semi-transparent par défaut au lieu d'être invisible
- Meilleure découvrabilité sur desktop et accessibilité sur mobile

## Changements
1. **MonthView**: Changé `opacity-0` par `opacity-40` pour le bouton d'ajout
2. **WeekView**: Même changement appliqué pour cohérence
3. Le bouton devient complètement opaque (`opacity-100`) au hover

## Avant/Après
- **Avant**: Bouton invisible, apparaît seulement au hover (problématique sur mobile)
- **Après**: Bouton semi-transparent toujours visible, devient plus visible au hover

## Tests
- ✅ Compilation TypeScript validée
- ✅ Visibilité améliorée sur desktop
- ✅ Bouton accessible sur mobile (plus besoin de hover)

Fixes #7

🤖 Generated with [Claude Code](https://claude.ai/code)