### PR TITLE
🚨 HOTFIX: Fix calendar meals not showing due to hardcoded userId mismatch

### DIFF
--- a/backend/src/common/constants/index.ts
+++ b/backend/src/common/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './temp-user.constant';

--- a/backend/src/common/constants/temp-user.constant.ts
+++ b/backend/src/common/constants/temp-user.constant.ts
@@ -1,0 +1,5 @@
+/**
+ * Temporary user ID constant for development
+ * TODO: Replace with proper authentication context
+ */
+export const TEMP_USER_ID = '798f47e6-dba4-4fbd-934a-0aa2599e4242';

--- a/backend/src/features/calendar/calendar.service.ts
+++ b/backend/src/features/calendar/calendar.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, Between } from 'typeorm';
 import { Meal } from '../meals/entities/meal.entity';
 import { NutritionService, NutritionGoals } from '../nutrition/nutrition.service';
+import { TEMP_USER_ID } from '../../common/constants/temp-user.constant';
 import { 
   startOfMonth, 
   endOfMonth, 
@@ -88,7 +89,7 @@ export class CalendarService {
     const meals = await this.mealsRepository.find({
       where: {
         date: Between(startDate, endDate),
-        userId: '798f47e6-dba4-4fbd-934a-0aa2599e4242', // This should come from auth context
+        userId: TEMP_USER_ID, // TODO: This should come from auth context
       },
       relations: ['foods', 'foods.food'],
       order: { date: 'ASC' },
@@ -218,7 +219,7 @@ export class CalendarService {
     const meals = await this.mealsRepository.find({
       where: {
         date: Between(start, end),
-        userId: '798f47e6-dba4-4fbd-934a-0aa2599e4242', // This should come from auth context
+        userId: TEMP_USER_ID, // TODO: This should come from auth context
       },
       relations: ['foods', 'foods.food'],
       order: { date: 'ASC', time: 'ASC' },
@@ -306,7 +307,7 @@ export class CalendarService {
     const meals = await this.mealsRepository.find({
       where: {
         date: Between(start, end),
-        userId: '798f47e6-dba4-4fbd-934a-0aa2599e4242', // This should come from auth context
+        userId: TEMP_USER_ID, // TODO: This should come from auth context
       },
       select: ['date'],
       order: { date: 'ASC' },
@@ -373,7 +374,7 @@ export class CalendarService {
     const meals = await this.mealsRepository.find({
       where: {
         date: Between(start, end),
-        userId: '798f47e6-dba4-4fbd-934a-0aa2599e4242', // This should come from auth context
+        userId: TEMP_USER_ID, // TODO: This should come from auth context
       },
       relations: ['foods', 'foods.food'],
       order: { date: 'ASC' },

--- a/backend/src/features/meals/meals.service.ts
+++ b/backend/src/features/meals/meals.service.ts
@@ -4,6 +4,7 @@ import { Repository, Between, DataSource, QueryRunner } from 'typeorm';
 import { Meal, MealCategory } from './entities/meal.entity';
 import { FoodEntry } from '../foods/entities/food-entry.entity';
 import { Food } from '../foods/entities/food.entity';
+import { TEMP_USER_ID } from '../../common/constants/temp-user.constant';
 import { 
   CreateMealDto, 
   UpdateMealDto, 
@@ -252,7 +253,7 @@ export class MealsService {
         time: createMealDto.time,
         notes: createMealDto.notes,
         isCustomCategory: !!createMealDto.category, // Track if category was manually set
-        userId: createMealDto.userId, // TODO: Get from auth context
+        userId: createMealDto.userId || TEMP_USER_ID, // TODO: Get from auth context
       };
 
       const meal = queryRunner.manager.create(Meal, mealData);

--- a/backend/src/features/nutrition/nutrition.service.ts
+++ b/backend/src/features/nutrition/nutrition.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, Between } from 'typeorm';
 import { Meal } from '../meals/entities/meal.entity';
 import { FoodEntry } from '../foods/entities/food-entry.entity';
+import { TEMP_USER_ID } from '../../common/constants/temp-user.constant';
 import { startOfDay, endOfDay, format, startOfWeek, endOfWeek, startOfMonth, endOfMonth, eachDayOfInterval } from 'date-fns';
 
 export interface NutritionSummary {
@@ -61,7 +62,7 @@ export class NutritionService {
     const meal = await this.mealsRepository.findOne({
       where: { 
         id: mealId,
-        userId: '798f47e6-dba4-4fbd-934a-0aa2599e4242', // This should come from auth context
+        userId: TEMP_USER_ID, // TODO: This should come from auth context
       },
       relations: ['foods', 'foods.food'],
     });
@@ -90,7 +91,7 @@ export class NutritionService {
       .leftJoinAndSelect('meal.foods', 'foods')
       .leftJoinAndSelect('foods.food', 'food')
       .where('meal.date = :date', { date })
-      .andWhere('meal.userId = :userId', { userId: '798f47e6-dba4-4fbd-934a-0aa2599e4242' })
+      .andWhere('meal.userId = :userId', { userId: TEMP_USER_ID })
       .orderBy('meal.createdAt', 'ASC')
       .getMany();
 
@@ -125,7 +126,7 @@ export class NutritionService {
     const meals = await this.mealsRepository.find({
       where: {
         date: Between(startOfDay(start), endOfDay(end)),
-        userId: '798f47e6-dba4-4fbd-934a-0aa2599e4242', // This should come from auth context
+        userId: TEMP_USER_ID, // TODO: This should come from auth context
       },
       relations: ['foods', 'foods.food'],
       order: { date: 'ASC', createdAt: 'ASC' },


### PR DESCRIPTION
## 🚨 Critical Hotfix

This PR fixes the issue where meals are not appearing on calendar cards due to hardcoded userId mismatches between services.

## Problem
- CalendarService and NutritionService were using hardcoded userId: `798f47e6-dba4-4fbd-934a-0aa2599e4242`
- MealsService was creating meals without a userId (or with a different one)
- This mismatch caused calendar views to show empty meal cards

## Solution
- Created a temporary user ID constant (`TEMP_USER_ID`) in `/src/common/constants/`
- Updated all services to use the same constant
- MealsService now defaults to `TEMP_USER_ID` when no userId is provided
- All services now consistently use the same userId value

## Changes
- ✅ Added `TEMP_USER_ID` constant
- ✅ Updated CalendarService to use the constant
- ✅ Updated NutritionService to use the constant  
- ✅ Updated MealsService to default to the constant
- ✅ Added proper exports for the constants module

## Testing
- Calendar views should now display meals correctly
- Nutrition calculations should work properly
- All existing functionality remains intact

## Next Steps
- This is a temporary fix until proper authentication is implemented
- All TODO comments have been preserved for future auth implementation

Fixes #31

🤖 Generated with [Claude Code](https://claude.ai/code)