### PR TITLE
fix: restore calendar navigation buttons in day view

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - NODE_ENV=production
       - PORT=3001
       - DATABASE_PATH=/app/data/foodtracker.db
-      - FRONTEND_URL=http://localhost:3000
+      - FRONTEND_URL=http://localhost:3003
     volumes:
       - ./data:/app/data
     restart: unless-stopped
@@ -23,10 +23,10 @@ services:
     build:
       context: .
       dockerfile: ./frontend/Dockerfile
+      args:
+        - VITE_API_URL=http://localhost:3002
     ports:
       - "3003:80"
-    environment:
-      - VITE_API_URL=http://localhost:3002
     depends_on:
       - backend
     restart: unless-stopped

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -35,7 +35,9 @@ COPY frontend/tailwind.config.js ./tailwind.config.js
 COPY frontend/postcss.config.js ./postcss.config.js
 COPY frontend/tsconfig*.json ./
 
-# Build application
+# Build application with API URL
+ARG VITE_API_URL=http://localhost:3001
+ENV VITE_API_URL=$VITE_API_URL
 RUN npm run build
 
 # Production image with nginx

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,6 @@ import { Toaster } from '@/components/ui/toaster';
 import Layout from '@/components/Layout';
 import HomePage from '@/pages/HomePage';
 import CalendarView from '@/features/calendar/components/CalendarView';
-import DayView from '@/features/calendar/components/DayView';
 import WeekView from '@/features/calendar/components/WeekView';
 import FoodSearch from '@/features/foods/components/FoodSearch';
 import './App.css';
@@ -27,7 +26,7 @@ function App() {
             <Routes>
               <Route path="/" element={<HomePage />} />
               <Route path="/calendar" element={<CalendarView />} />
-              <Route path="/day/:date" element={<DayView />} />
+              <Route path="/day/:date" element={<CalendarView />} />
               <Route path="/week/:date?" element={<WeekView />} />
               <Route path="/foods" element={<FoodSearch />} />
             </Routes>

--- a/frontend/src/features/calendar/components/CalendarView.tsx
+++ b/frontend/src/features/calendar/components/CalendarView.tsx
@@ -1,15 +1,33 @@
-import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { format } from 'date-fns';
 import { Button } from '@/components/ui/button';
 import MonthView from './MonthView';
 import WeekView from './WeekView';
+import DayView from './DayView';
 
 type ViewType = 'month' | 'week' | 'day';
 
 const CalendarView: React.FC = () => {
   const [viewType, setViewType] = useState<ViewType>('month');
   const navigate = useNavigate();
+  const { date } = useParams<{ date?: string }>();
+
+  // If we're on a day route, set the view to day
+  useEffect(() => {
+    if (date) {
+      setViewType('day');
+    }
+  }, [date]);
+
+  const handleDayClick = () => {
+    setViewType('day');
+    // Navigate to the day view with today's date if not already on a date
+    if (!date) {
+      const today = format(new Date(), 'yyyy-MM-dd');
+      navigate(`/day/${today}`);
+    }
+  };
 
   return (
     <div className="space-y-6">
@@ -20,25 +38,27 @@ const CalendarView: React.FC = () => {
           <Button
             variant={viewType === 'month' ? 'default' : 'outline'}
             size="sm"
-            onClick={() => setViewType('month')}
+            onClick={() => {
+              setViewType('month');
+              navigate('/calendar');
+            }}
           >
             Month
           </Button>
           <Button
             variant={viewType === 'week' ? 'default' : 'outline'}
             size="sm"
-            onClick={() => setViewType('week')}
+            onClick={() => {
+              setViewType('week');
+              navigate('/calendar');
+            }}
           >
             Week
           </Button>
           <Button
             variant={viewType === 'day' ? 'default' : 'outline'}
             size="sm"
-            onClick={() => {
-              // When switching to day view, navigate to today's date
-              const today = format(new Date(), 'yyyy-MM-dd');
-              navigate(`/day/${today}`);
-            }}
+            onClick={handleDayClick}
           >
             Day
           </Button>
@@ -47,6 +67,7 @@ const CalendarView: React.FC = () => {
 
       {viewType === 'month' && <MonthView />}
       {viewType === 'week' && <WeekView />}
+      {viewType === 'day' && date && <DayView />}
     </div>
   );
 };

--- a/frontend/src/features/calendar/components/DayView.tsx
+++ b/frontend/src/features/calendar/components/DayView.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { format } from 'date-fns';
 import { 
-  ArrowLeft, 
   Plus, 
   Edit, 
   Trash2, 
@@ -182,17 +181,9 @@ const DayView: React.FC = () => {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center space-x-4">
-          <Button variant="outline" size="sm" asChild>
-            <Link to="/calendar">
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to Calendar
-            </Link>
-          </Button>
-          <h1 className="text-2xl font-semibold">
-            {formatCalendarDate(date!)}
-          </h1>
-        </div>
+        <h1 className="text-2xl font-semibold">
+          {formatCalendarDate(date!)}
+        </h1>
       </div>
 
       {/* Daily Summary with Enhanced Visuals */}


### PR DESCRIPTION
## Summary
- Fixed bug where Month/Week/Day navigation buttons disappear when clicking on Day view
- Modified routing structure to maintain consistent navigation throughout the app
- Fixed additional issues with CORS and API connection in Docker setup

## Changes
- Changed route for `/day/:date` to load `CalendarView` instead of `DayView` directly
- Added view type state management in `CalendarView` to handle inline day view rendering
- Removed redundant navigation elements from `DayView` component
- Fixed TypeScript errors from unused imports
- Updated Docker configuration for proper CORS handling

## Test plan
- [x] Navigate to calendar view
- [x] Click on Day button - navigation buttons should remain visible
- [x] Click on Month/Week buttons - should switch views correctly
- [x] Navigate directly to a day URL (e.g., `/day/2025-07-27`) - should show day view with navigation buttons
- [x] All TypeScript errors resolved
- [x] Frontend builds successfully

Fixes #41